### PR TITLE
Fix log statement for enriched markdown output

### DIFF
--- a/packages/cli/src/process.ts
+++ b/packages/cli/src/process.ts
@@ -363,7 +363,9 @@ export async function processConversion(inputPathArg: string, options: any) {
         result.markdownResultFromEnrichmentLLM
       );
 
-      logger.info(`Writing cleaned enriched markdown to: }`);
+      logger.info(
+        `Writing cleaned enriched markdown to: ${enrichedMarkdownOutputLocation}`
+      );
 
       await fs.writeFile(
         enrichedMarkdownOutputLocation,


### PR DESCRIPTION
## Summary
- log the output path when writing cleaned enriched markdown

## Testing
- `yarn test` *(fails: makeBloomHtml.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_6840f1bca9ac8331a02b6be2f14db888