### PR TITLE
Fix typo in error message

### DIFF
--- a/packages/cli/src/process.ts
+++ b/packages/cli/src/process.ts
@@ -372,7 +372,7 @@ export async function processConversion(inputPathArg: string, options: any) {
 
       if (!result.valid) {
         throw new Error(
-          `Enrichment process returned invalid content. This can be a result of the mode/prompt. You may be able to errors in the file "${enrichedMarkdownOutputLocation}" for details.`
+          `Enrichment process returned invalid content. This can be a result of the mode/prompt. You may be able to see errors in the file "${enrichedMarkdownOutputLocation}" for details.`
         );
       }
       currentProcessingFilePath = enrichedMarkdownOutputLocation; // Update current file path


### PR DESCRIPTION
## Summary
- fix wording in error message

## Testing
- `yarn test` *(fails: Test Files 4 failed)*

------
https://chatgpt.com/codex/tasks/task_e_6840f1b8fb188331b5c11b98dc72f544