### PR TITLE
Update llmMarkdown test expectations

### DIFF
--- a/packages/lib/src/2-llm-markdown/llmMarkdown.test.ts
+++ b/packages/lib/src/2-llm-markdown/llmMarkdown.test.ts
@@ -1,13 +1,13 @@
 import { describe, it, expect } from "vitest";
-import { enrichMarkdown } from "./enrichMarkdown";
+import { llmMarkdown } from "./llmMarkdown";
 import { LogEntry } from "../logger";
 
-describe("enrichMarkdown", () => {
+describe("llmMarkdown", () => {
   it("should throw error when API key is missing", async () => {
     const logs: LogEntry[] = [];
 
     await expect(
-      enrichMarkdown("# Test", "", { logCallback: (log) => logs.push(log) })
+      llmMarkdown("# Test", "", { logCallback: (log) => logs.push(log) })
     ).rejects.toThrow("OpenRouter API key is required");
 
     expect(
@@ -20,7 +20,7 @@ describe("enrichMarkdown", () => {
   });
   it("should log enrichment process", async () => {
     const logs: LogEntry[] = [];
-    const result = await enrichMarkdown("# Test", "valid-key", {
+    const result = await llmMarkdown("# Test", "valid-key", {
       logCallback: (log) => logs.push(log),
     });
 
@@ -35,18 +35,18 @@ describe("enrichMarkdown", () => {
       logs.some(
         (log) =>
           log.level === "info" &&
-          log.message === "Markdown enrichment completed successfully"
+          log.message === "Markdown enrichment completed... validating..."
       )
     ).toBe(true);
     expect(result).toContain("<!-- Enriched Content via OpenRouter -->");
   });
   it("should work without options", async () => {
-    const result = await enrichMarkdown("# Test", "valid-key");
+    const result = await llmMarkdown("# Test", "valid-key");
     expect(result).toContain("<!-- Enriched Content via OpenRouter -->");
   });
 
   it("should work with partial options", async () => {
-    const result = await enrichMarkdown("# Test", "valid-key", {
+    const result = await llmMarkdown("# Test", "valid-key", {
       overridePrompt: "Custom prompt",
       overrideModel: "custom-model",
     });


### PR DESCRIPTION
## Summary
- import `llmMarkdown` directly in the markdown enrichment tests
- update test descriptions to match the function name
- check for the log message `Markdown enrichment completed... validating...`

## Testing
- `yarn test` *(fails: Mistral AI OCR processing failed and llmMarkdown tests timed out)*

------
https://chatgpt.com/codex/tasks/task_e_6840f190e1e083318db24719f9342e63