### PR TITLE
Add metadata comments in markdown body

### DIFF
--- a/packages/lib/src/2-llm-markdown/llmPrompt.txt
+++ b/packages/lib/src/2-llm-markdown/llmPrompt.txt
@@ -9,12 +9,13 @@ You are given a Markdown file that may contain multiple languages. Your task is 
         - Credits (author, illustrator, researchers)
         - Tags (e.g., topic, language)
         - Publisher and location information (country, province, district)
-    2. Format this metadata as YAML front matter and insert it at the very top of the Markdown file using `--` delimiters. Here is a sample
+    2. Format this metadata as YAML front matter and insert it at the very top of the Markdown file using `---` delimiters.
 
-    3. Annotate all blocks of text with a language comment. E.g. `<!-- lang=en --> This is my house. <!-- lang=fr --> C'est ma maison.` 
-        - Use ISO 639-1 or 639-3 language codes (e.g., `es` for Spanish, `mxa` for Mixteco de Santa María Zacatepec, uz-CYRL for Uzbeck in cyrillic script).
-        - Preserve Markdown formatting
-        - Preserve all image references
+    3. Annotate all blocks of text with a language comment. E.g. `<!-- lang=en --> This is my house. <!-- lang=fr --> C'est ma maison.`
+    - Use ISO 639-1 or 639-3 language codes (e.g., `es` for Spanish, `mxa` for Mixteco de Santa María Zacatepec, uz-CYRL for Uzbeck in cyrillic script).
+    - Preserve Markdown formatting
+    - Preserve all image references
+    - Use the same style to tag each metadata field. Place these comments in the body of the markdown, not in the YAML front matter. Example: `<!-- lang="fr" field="copyright" -->` or `<!-- lang="en" field="ISBN" -->`.
 
     4. Preserve all incoming comments. The input markdown may already have `<!-- start-page -->` comments.
     
@@ -47,7 +48,16 @@ You are given a Markdown file that may contain multiple languages. Your task is 
     publisher: "Instituto de Grillo"
     originalPublisher: "Someone else that we derived from."
     ---
-    
+
+    <!-- lang=en field="title" -->
+    The moon and the cap
+
+    <!-- start-page -->
+    <!-- lang=en field="copyright" -->
+    Copyright 1993, Instituto Lingüístico de Verano, A.C.
+    <!-- lang=en field="license" -->
+    CC-BY-NC
+
     ![](/myHouse.jpg)
     
     <!-- lang=en -->


### PR DESCRIPTION
## Summary
- update instructions: keep front matter clean and add metadata tagging comments in the body
- revise sample prompt to show metadata lines with language comments

## Testing
- `yarn install`
- `yarn test` *(fails: Test Files 4 failed)*

------
https://chatgpt.com/codex/tasks/task_e_6840f0a8ad548331bf28772ebccd10d8